### PR TITLE
clean up setup for use with python3 pip install mutt-ldap

### DIFF
--- a/README
+++ b/README
@@ -3,6 +3,46 @@ connects to LDAP_ databases using python-ldap_.  It can cache queries
 locally in case your LDAP server is slow or not always available,
 expiring cached queries after a configurable amount of time.
 
+Usage
+=====
+
+  usage: mutt_ldap [-h] [--version] [--config CONFIG] [--verbose]
+                  query [query ...]
+
+positional arguments:
+  query            Search query for the LDAP directory
+
+optional arguments:
+  --config CONFIG  Path to the configuration file
+
+If the ``xdg`` module supplied by PyXDG_ is not available, the default
+configuration path falls back on ``~/.config/mutt-ldap.cfg`` and the default
+cache path falls back on ``~/.cache/mutt-ldap.json``.
+
+To use in mutt, add the following line to your ``~/.muttrc``::
+
+  set query_command = "mutt_ldap.py '%s'"
+
+Search for addresses (from Mutt_) with ``^t``, optionally after typing
+part of the name.  Configure your connection by creating
+``$XDG_CONFIG_HOME/mutt-ldap.cfg`` containing something like::
+
+  [connection]
+  server = myserver.example.net
+  port   = 1389
+  basedn = ou=people,dc=example,dc=net
+  [auth]
+  user         = username
+  password-cmd = pass example
+
+The query cache (enabled by default) will be created at
+``$XDG_DATA_HOME/mutt-ldap.json``, unless overriden by an explicit
+``cache.path`` setting.
+
+See the ``CONFIG`` options in ``mutt_ldap.py`` for other available
+settings.  See the `XDG Base Directory Specification`_ for more
+details on configuration and cache file locations.  
+
 Installation
 ============
 
@@ -46,32 +86,6 @@ standard::
 
 or you can just copy ``mutt_ldap.py`` into to your ``PATH``.
 
-Usage
-=====
-
-Add the following line to your ``~/.muttrc``::
-
-  set query_command = "mutt_ldap.py '%s'"
-
-Search for addresses (from Mutt_) with ``^t``, optionally after typing
-part of the name.  Configure your connection by creating
-``$XDG_CONFIG_HOME/mutt-ldap.cfg`` containing something like::
-
-  [connection]
-  server = myserver.example.net
-  basedn = ou=people,dc=example,dc=net
-
-The query cache (enabled by default) will be created at
-``$XDG_DATA_HOME/mutt-ldap.json``, unless overriden by an explicit
-``cache.path`` setting.
-
-See the ``CONFIG`` options in ``mutt_ldap.py`` for other available
-settings.  See the `XDG Base Directory Specification`_ for more
-details on configuration and cache file locations.  If the ``xdg``
-module supplied by PyXDG_ is not available, the default configuration
-path falls back on ``~/.config/mutt-ldap.cfg`` and the default cache
-path falls back on ``~/.cache/mutt-ldap.json``.
-
 Licence
 =======
 
@@ -89,19 +103,36 @@ Related work
 `mutt_ldap_query`_ is a Perl script with a similar purpose.
 
 .. _external address query script:
-   http://www.mutt.org/doc/manual/manual-4.html#ss4.5
-.. _Mutt: http://www.mutt.org/
-.. _LDAP: http://en.wikipedia.org/wiki/Lightweight_Directory_Access_Protocol
-.. _python-ldap: http://www.python-ldap.org/
-.. _Gentoo: http://www.gentoo.org/
-.. _layman: http://layman.sourceforge.net/
-.. _wtk overlay: http://blog.tremily.us/posts/Gentoo_overlay/
-.. _Debian: http://www.debian.org/
-.. _PyXDG: http://freedesktop.org/wiki/Software/pyxdg
-.. _Git: http://git-scm.com/
+   [www][0]
+.. _Mutt: [www][1]
+.. _LDAP: [en][2]
+.. _python-ldap: [www][3]
+.. _Gentoo: [www][4]
+.. _layman: [layman][5]
+.. _wtk overlay: [blog][6]
+.. _Debian: [www][7]
+.. _PyXDG: [freedesktop][8]
+.. _Git: [git-scm][9]
 .. _XDG Base Directory Specification:
-   http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
-.. _GNU General Public License Version 3: http://www.gnu.org/licenses/gpl.html
-.. _GitHub: https://github.com/wking/mutt-ldap
-.. _GitHub issue tracker: https://github.com/wking/mutt-ldap/issues
+   [standards][10]
+.. _GNU General Public License Version 3: [www][11]
+.. _GitHub: [github][12]
+.. _GitHub issue tracker: [github][13]
 .. _mutt_ldap_query: ftp://ftp.mutt.org/pub/mutt/contrib/mutt_ldap_query.README
+
+## Links
+
+[0]: [www](http://www.mutt.org/doc/manual/manual-4.html#ss4.5)
+[1]: [www](http://www.mutt.org/)
+[2]: [en](http://en.wikipedia.org/wiki/Lightweight_Directory_Access_Protocol)
+[3]: [www](http://www.python-ldap.org/)
+[4]: [www](http://www.gentoo.org/)
+[5]: [layman](http://layman.sourceforge.net/)
+[6]: [blog](http://blog.tremily.us/posts/Gentoo_overlay/)
+[7]: [www](http://www.debian.org/)
+[8]: [freedesktop](http://freedesktop.org/wiki/Software/pyxdg)
+[9]: [git-scm](http://git-scm.com/)
+[10]: [standards](http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html)
+[11]: [www](http://www.gnu.org/licenses/gpl.html)
+[12]: [github](https://github.com/wking/mutt-ldap)
+[13]: [github](https://github.com/wking/mutt-ldap/issues)

--- a/setup.py
+++ b/setup.py
@@ -13,35 +13,36 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from distutils.core import setup as _setup
-import os.path as _os_path
+from setuptools import setup
+import os
 
-import mutt_ldap as _mutt_ldap
+with open(os.path.join(os.path.dirname(__file__), "README.rst"), encoding="utf-8") as f:
+    readme = f.read()
 
-
-_this_dir = _os_path.dirname(__file__)
-
-_setup(
-    name='mutt-ldap',
-    version=_mutt_ldap.__version__,
-    maintainer='W. Trevor King',
-    maintainer_email='wking@tremily.us',
+setup(
+    name="mutt-ldap",
+    maintainer="W. Trevor King",
+    maintainer_email="wking@tremily.us",
     url='http://blog.tremily.us/posts/mutt-ldap/',
-    download_url='http://git.tremily.us/?p=mutt-ldap.git;a=snapshot;h=v{};sf=tgz'.format(_mutt_ldap.__version__),
-    license = 'GNU General Public License (GPL)',
-    platforms = ['all'],
-    description = _mutt_ldap.__doc__.splitlines()[0],
-    long_description=open(_os_path.join(_this_dir, 'README'), 'r').read(),
-    classifiers = [
-        'Development Status :: 3 - Alpha',
-        'Intended Audience :: End Users/Desktop',
-        'Operating System :: OS Independent',
-        'License :: OSI Approved :: GNU General Public License (GPL)',
-        'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7',
-        'Topic :: Communications :: Email',
-        ],
-    py_modules = ['mutt_ldap'],
-    scripts = ['mutt_ldap.py'],
-    )
+    download_url = f"https://github.com/wberrier/mutt-ldap/archive/refs/tags/v{_mutt_ldap.__version__}.tar.gz"
+    license="GNU General Public License (GPL)",
+    description="A tool to query an LDAP server for email addresses and names, suitable for use with Mutt.",
+    long_description=readme,
+    long_description_content_type="text/rst",
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: End Users/Desktop",
+        "Operating System :: OS Independent",
+        "License :: OSI Approved :: GNU General Public License (GPL)",
+        "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
+        "Programming Language :: Python :: 3",
+        "Topic :: Communications :: Email",
+    ],
+    platforms=['all'],
+    packages=[],
+    scripts=["mutt_ldap.py"],
+    py_modules=["mutt_ldap"],
+    install_requires=[
+        "python-ldap>=3.0",
+    ],
+)


### PR DESCRIPTION
clean up setup for use with python3 pip install mutt-ldap

unfortunately the ldap module still seems to depend on C source as shows the
error message

gcc -pthread -Wsign-compare -DNDEBUG -fmessage-length=0 -grecord-gcc-switches -O2 -Wall -D_FORTIFY_SOURCE=2 -fstack-protector-strong -funwind-tables -fasynchronous-unwind-tables -fstack-clash-protection -g -DOPENSSL_LOAD_CONF -fwrapv -fno-semantic-interposition -fmessage-length=0 -grecord-gcc-switches -O2 -Wall -D_FORTIFY_SOURCE=2 -fstack-protector-strong -funwind-tables -fasynchronous-unwind-tables -fstack-clash-protection -g -IVendor/ -fmessage-length=0 -grecord-gcc-switches -O2 -Wall -D_FORTIFY_SOURCE=2 -fstack-protector-strong -funwind-tables -fasynchronous-unwind-tables -fstack-clash-protection -g -IVendor/ -fPIC -DHAVE_SASL -DHAVE_TLS -DLDAPMODULE_VERSION=3.4.4 "-DLDAPMODULE_AUTHOR=python-ldap project" "-DLDAPMODULE_LICENSE=Python style" -IModules -I/usr/include/python3.11 -c Modules/LDAPObject.c -o build/temp.linux-x86_64-cpython-311/Modules/LDAPObject.o
In file included from Modules/LDAPObject.c:3:0:
Modules/common.h:9:10: fatal error: Python.h: File o directory non esistente
        ^~~~~~~~~~
compilation terminated.
error: command '/usr/bin/gcc' failed with exit code 1
